### PR TITLE
[Actions] Do not re-run PR action after merge

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,8 +8,6 @@
 name: Pull Request
 
 on:
-  push:
-    branches: [ develop, main ]
   pull_request:
     types: [ opened, reopened, ready_for_review, synchronize ]
 


### PR DESCRIPTION
### Description
Currently the PR action is also triggered by a push on `main` or `develop` branch. That is not needed as all changes to `main` branch need to be reviewed first. This just triggers another PR run after a PR was merged.