### PR TITLE
Block context sharing with Gemini in Android Studio

### DIFF
--- a/.aiexclude
+++ b/.aiexclude
@@ -1,0 +1,3 @@
+# Intentionally empty, an empty .aiexclude file blocks all files in its directory
+# and all sub-directories, recursively.
+# https://developer.android.com/studio/preview/gemini/aiexclude#how-write


### PR DESCRIPTION
### Description

Starting with Android Studio Iguana the `Studio Bot` is available and starting with Android Studio Jellyfish it’s been renamed to `Gemini in Android Studio`. While this is nice tech which can speed up development, we need to be careful to not share internals or other details.

It’s possible to share data (aka `context`) with `Gemini` in order to get “better” recommendations or inline code completion. There might be other features in the future.

With a `.aiexclude` file at project root level, it’s possible to restrict which files shouldn’t be shared with Google. [If the file is empty, nothing is shared.](https://developer.android.com/studio/preview/gemini/aiexclude#how-write). That's the baseline for projects and can be configured as per project decisions.