### PR TITLE
Bump kotlin to 2.0.0

### DIFF
--- a/build-logic/convention/src/main/kotlin/net/grandcentrix/baseproject/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/net/grandcentrix/baseproject/AndroidCompose.kt
@@ -9,13 +9,10 @@ import org.gradle.kotlin.dsl.dependencies
  */
 internal fun Project.configureAndroidCompose(commonExtension: CommonExtension<*, *, *, *, *, *>) {
     commonExtension.apply {
+        pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
+
         buildFeatures {
             compose = true
-        }
-
-        composeOptions {
-            kotlinCompilerExtensionVersion =
-                libs.findVersion("androidx-compose-compiler").get().toString()
         }
 
         dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
     alias(libs.plugins.detekt) apply false
+    alias(libs.plugins.compose.compiler) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ detekt = "1.23.6"
 androidx-appcompat = "1.7.0"
 androidx-activity = "1.9.0"
 androidx-coreKtx = "1.13.1"
-androidx-compose-compiler = "1.5.11"
 androidx-compose-bom = "2024.05.00"
 
 # Testing
@@ -36,6 +35,7 @@ android_gradle_plugin = { id = "com.android.tools.build:gradle", version.ref = "
 kotlin_gradle_plugin = { id = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 detekt-gradle-plugin = { id = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 
 # Plugins defined by this project
 grandcentrix_application = { id = "net.grandcentrix.android.application", version = "unspecified" }


### PR DESCRIPTION
#### Description:
- Bumps kotlin from `1.9.23` to `2.0.0`
- Uses compose compiler plugin
