### PR TITLE
[Improvement] Remove deprecated kotlinOptions

### DIFF
--- a/build-logic/convention/src/main/kotlin/net/grandcentrix/baseproject/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/net/grandcentrix/baseproject/KotlinAndroid.kt
@@ -3,8 +3,9 @@ package net.grandcentrix.baseproject
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 /**
  * Configure base Kotlin with Android options
@@ -25,12 +26,8 @@ internal fun Project.configureKotlinAndroid(commonExtension: CommonExtension<*, 
 /**
  * Configure base Kotlin options
  */
-private fun Project.configureKotlin() {
-    // Use withType to workaround https://youtrack.jetbrains.com/issue/KT-55947
-    tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            // Set JVM target to 17
-            jvmTarget = JavaVersion.VERSION_17.toString()
-        }
+private fun Project.configureKotlin() = configure<KotlinAndroidProjectExtension> {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }


### PR DESCRIPTION
### Description
Starting with kotlin 2.0.0 `kotlinOptions` are deprecated and should be replaced with `compilerOptions`.